### PR TITLE
Speed up /admin statistics page "Requests & Events"

### DIFF
--- a/omaha_server/omaha/views_admin.py
+++ b/omaha_server/omaha/views_admin.py
@@ -181,7 +181,6 @@ class RequestListView(StaffMemberRequiredMixin, SingleTableView):
         except Application.DoesNotExist:
             raise Http404
 
-        qs = qs.distinct()
         self.filter = AppRequestFilter(self.request.GET, queryset=qs)
         return self.filter.qs
 


### PR DESCRIPTION
When there are millions of requests in the database, this page took tens of seconds to load. In extreme situations, it could even DoS the database, and thus kill the server.

The reason was an unnecessary `.distinct()` call on the QuerySet that contains the `AppRequest`s. The call was unnecessary because Django automatically fetches the `id` for each `AppRequest`. Every row thus had a unique `id`, and was thus necessarily distinct from all the others. This PR removes the `.distinct()` call, which leads to a very significant performance improvement.